### PR TITLE
Add minor enhancements in init script for testing outside docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ route53-failover/lambda-functions/lambda-functions.iml
 /extension-outages/terraform/.terraform
 /extension-outages/terraform/.terraform.lock.hcl
 /extension-outages/terraform/terraform.tfstate
+
+target/

--- a/FIS-experiments/init-resources.sh
+++ b/FIS-experiments/init-resources.sh
@@ -18,7 +18,7 @@ awslocal dynamodb create-table \
         --table-name Products \
         --attribute-definitions AttributeName=id,AttributeType=S \
         --key-schema AttributeName=id,KeyType=HASH \
-         --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+        --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
 
 
 # create Lambdas

--- a/FIS-experiments/init-resources.sh
+++ b/FIS-experiments/init-resources.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 
-apt-get -y install jq
+LAMBDAS_DIR=/etc/localstack/init/ready.d
+if [[ ! -e $LAMBDAS_DIR ]]; then
+  # for local testing, running the script directly on the host (without init hooks)
+  LAMBDAS_DIR=./lambda-functions
+fi
+
+# set region globally
+export AWS_DEFAULT_REGION=us-east-1
+
+# install `jq`, if not yet available
+which jq || apt-get -y install jq
 
 # create table
 echo "Create DynamoDB table..."
@@ -8,8 +18,7 @@ awslocal dynamodb create-table \
         --table-name Products \
         --attribute-definitions AttributeName=id,AttributeType=S \
         --key-schema AttributeName=id,KeyType=HASH \
-         --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
-        --region us-east-1
+         --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
 
 
 # create Lambdas
@@ -20,10 +29,10 @@ awslocal lambda create-function \
   --runtime java17 \
   --handler lambda.AddProduct::handleRequest \
   --memory-size 1024 \
-  --zip-file fileb:///etc/localstack/init/ready.d/target/product-lambda.jar \
-  --region us-east-1 \
+  --timeout 45 \
+  --zip-file fileb://$LAMBDAS_DIR/target/product-lambda.jar \
   --role arn:aws:iam::000000000000:role/productRole \
-  --environment Variables={AWS_REGION=us-east-1}
+  --environment Variables={AWS_REGION=$AWS_DEFAULT_REGION}
 
 
 echo "Get Product Lambda..."
@@ -32,27 +41,26 @@ awslocal lambda create-function \
   --runtime java17 \
   --handler lambda.GetProduct::handleRequest \
   --memory-size 1024 \
-  --zip-file fileb:///etc/localstack/init/ready.d/target/product-lambda.jar \
-  --region us-east-1 \
+  --timeout 45 \
+  --zip-file fileb://$LAMBDAS_DIR/target/product-lambda.jar \
   --role arn:aws:iam::000000000000:role/productRole \
-  --environment Variables={AWS_REGION=us-east-1}
+  --environment Variables={AWS_REGION=$AWS_DEFAULT_REGION}
 
 export REST_API_ID=12345
 
 # create rest api gateway
 echo "Create Rest API..."
-awslocal apigateway create-rest-api --name quote-api-gateway --tags '{"_custom_id_":"12345"}' --region us-east-1
+awslocal apigateway create-rest-api --name quote-api-gateway --tags '{"_custom_id_":"12345"}'
 
 # get parent id of resource
 echo "Export Parent ID..."
-export PARENT_ID=$(awslocal apigateway get-resources --rest-api-id $REST_API_ID --region=us-east-1 | jq -r '.items[0].id')
+export PARENT_ID=$(awslocal apigateway get-resources --rest-api-id $REST_API_ID | jq -r '.items[0].id')
 
 # get resource id
 echo "Export Resource ID..."
-export RESOURCE_ID=$(awslocal apigateway create-resource --rest-api-id $REST_API_ID --parent-id $PARENT_ID --path-part "productApi" --region=us-east-1 | jq -r '.id')
+export RESOURCE_ID=$(awslocal apigateway create-resource --rest-api-id $REST_API_ID --parent-id $PARENT_ID --path-part "productApi" | jq -r '.id')
 
-echo "RESOURCE ID:"
-echo $RESOURCE
+echo "RESOURCE ID: $RESOURCE_ID"
 
 echo "Put GET Method..."
 awslocal apigateway put-method \
@@ -60,8 +68,7 @@ awslocal apigateway put-method \
 --resource-id $RESOURCE_ID \
 --http-method GET \
 --request-parameters "method.request.path.productApi=true" \
---authorization-type "NONE" \
---region=us-east-1
+--authorization-type "NONE"
 
 echo "Put POST Method..."
 awslocal apigateway put-method \
@@ -69,8 +76,7 @@ awslocal apigateway put-method \
 --resource-id $RESOURCE_ID \
 --http-method POST \
 --request-parameters "method.request.path.productApi=true" \
---authorization-type "NONE" \
---region=us-east-1
+--authorization-type "NONE"
 
 
 echo "Update GET Method..."
@@ -78,8 +84,7 @@ awslocal apigateway update-method \
   --rest-api-id $REST_API_ID \
   --resource-id $RESOURCE_ID \
   --http-method GET \
-  --patch-operations "op=replace,path=/requestParameters/method.request.querystring.param,value=true" \
-  --region=us-east-1
+  --patch-operations "op=replace,path=/requestParameters/method.request.querystring.param,value=true"
 
 
 echo "Put POST Method Integration..."
@@ -89,9 +94,8 @@ awslocal apigateway put-integration \
   --http-method POST \
   --type AWS_PROXY \
   --integration-http-method POST \
-  --uri arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:add-product/invocations \
-  --passthrough-behavior WHEN_NO_MATCH \
-  --region=us-east-1
+  --uri arn:aws:apigateway:$AWS_DEFAULT_REGION:lambda:path/2015-03-31/functions/arn:aws:lambda:$AWS_DEFAULT_REGION:000000000000:function:add-product/invocations \
+  --passthrough-behavior WHEN_NO_MATCH
 
 echo "Put GET Method Integration..."
 awslocal apigateway put-integration \
@@ -100,15 +104,13 @@ awslocal apigateway put-integration \
   --http-method GET \
   --type AWS_PROXY \
   --integration-http-method GET \
-  --uri arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:get-product/invocations \
-  --passthrough-behavior WHEN_NO_MATCH \
-  --region=us-east-1
+  --uri arn:aws:apigateway:$AWS_DEFAULT_REGION:lambda:path/2015-03-31/functions/arn:aws:lambda:$AWS_DEFAULT_REGION:000000000000:function:get-product/invocations \
+  --passthrough-behavior WHEN_NO_MATCH
 
 echo "Create DEV Deployment..."
 awslocal apigateway create-deployment \
   --rest-api-id $REST_API_ID \
-  --stage-name dev \
-  --region=us-east-1
+  --stage-name dev
 
 awslocal sns create-topic --name ProductEventsTopic
 
@@ -117,23 +119,23 @@ awslocal sqs create-queue --queue-name ProductEventsQueue
 awslocal sqs get-queue-attributes --queue-url http://localhost:4566/000000000000/ProductEventsQueue --attribute-names QueueArn
 
 awslocal sns subscribe \
-    --topic-arn arn:aws:sns:us-east-1:000000000000:ProductEventsTopic \
+    --topic-arn arn:aws:sns:$AWS_DEFAULT_REGION:000000000000:ProductEventsTopic \
     --protocol sqs \
-    --notification-endpoint arn:aws:sqs:us-east-1:000000000000:ProductEventsQueue
+    --notification-endpoint arn:aws:sqs:$AWS_DEFAULT_REGION:000000000000:ProductEventsQueue
 
 awslocal lambda create-function \
   --function-name process-product-events \
   --runtime java17 \
   --handler lambda.DynamoDBWriterLambda::handleRequest \
   --memory-size 1024 \
-  --zip-file fileb:///etc/localstack/init/ready.d/target/product-lambda.jar \
-  --region us-east-1 \
+  --timeout 20 \
+  --zip-file fileb://$LAMBDAS_DIR/target/product-lambda.jar \
   --role arn:aws:iam::000000000000:role/productRole
 
 awslocal lambda create-event-source-mapping \
     --function-name process-product-events \
     --batch-size 10 \
-    --event-source-arn arn:aws:sqs:us-east-1:000000000000:ProductEventsQueue
+    --event-source-arn arn:aws:sqs:$AWS_DEFAULT_REGION:000000000000:ProductEventsQueue
 
 awslocal sqs set-queue-attributes \
     --queue-url http://localhost:4566/000000000000/ProductEventsQueue \

--- a/FIS-experiments/lambda-functions/pom.xml
+++ b/FIS-experiments/lambda-functions/pom.xml
@@ -11,8 +11,8 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
   </properties>
 


### PR DESCRIPTION
Kudos for preparing this sample app @tinyg210 - works like a charm! 🚀 

Add minor enhancements in `init-resources.sh` script, to simplify testing on the host when starting up LS via the CLI, i.e., outside of docker-compose (and without the volume mounts).

Further proposed changes:
* define `AWS_DEFAULT_REGION` globally in the script, as opposed to specifying `--region` (makes the commands slightly shorter, and allows to change the region in a single place)
* change Java compile target version to 11, instead of 17, for better backwards-compatibility (I'm still a few versions behind! 😛 )
* slightly increase the timeouts of the Lambdas - the default timeout of 3 seconds causes some Lambda invocations to error out on my local machine